### PR TITLE
Add installation instructions ChefDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ This plugin is distributed as a Ruby Gem. To install it, run:
 
 Depending on your system's configuration, you may need to run this command with root privileges.
 
+
+If using ChefDK ( www.getchef.com/downloads/chef-dk/ )
+
+    chef gem install alchemist rbvmomi knife-esx
+
 ## CONFIGURATION:
 
 In order to communicate with the ESX Cloud API you will have to tell Knife about your Username and API Key.  The easiest way to accomplish this is to create some entries in your `knife.rb` file:

--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ This plugin is distributed as a Ruby Gem. To install it, run:
 Depending on your system's configuration, you may need to run this command with root privileges.
 
 
-If using ChefDK on OSX ( www.getchef.com/downloads/chef-dk/ ) - Currently held up by https://github.com/opscode/chef-dk/issues/46
+If using ChefDK on OSX ( www.getchef.com/downloads/chef-dk/ ) 
 
-    chef gem install alchemist knife-esx
-    /opt/chefdk/embedded/bin/gem install rbvmomi --version 1.6.0
-
+    chef gem install rbvmomi --version 1.6.0
+    chef gem install knife-esx
 
 ## CONFIGURATION:
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ This plugin is distributed as a Ruby Gem. To install it, run:
 Depending on your system's configuration, you may need to run this command with root privileges.
 
 
-If using ChefDK ( www.getchef.com/downloads/chef-dk/ )
+If using ChefDK ( www.getchef.com/downloads/chef-dk/ ) - Currently held up by https://github.com/opscode/chef-dk/issues/46
 
-    chef gem install alchemist rbvmomi knife-esx
+    chef gem install alchemist knife-esx
+    chef gem install rbvmomi --version 1.6.0     
+
 
 ## CONFIGURATION:
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ This plugin is distributed as a Ruby Gem. To install it, run:
 Depending on your system's configuration, you may need to run this command with root privileges.
 
 
-If using ChefDK ( www.getchef.com/downloads/chef-dk/ ) - Currently held up by https://github.com/opscode/chef-dk/issues/46
+If using ChefDK on OSX ( www.getchef.com/downloads/chef-dk/ ) - Currently held up by https://github.com/opscode/chef-dk/issues/46
 
     chef gem install alchemist knife-esx
-    chef gem install rbvmomi --version 1.6.0     
+    /opt/chefdk/embedded/bin/gem install rbvmomi --version 1.6.0
 
 
 ## CONFIGURATION:


### PR DESCRIPTION
ChefDK wraps its Gems with the new "chef" command line tool. "gem install knife-esx" does not install the knife-esx gem to the correct environment.
